### PR TITLE
Fix: Hex mode send logic bug

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -54,7 +54,6 @@ public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
 
-    void StringToHex(QString str, QByteArray &senddata);
     char ConvertHexChar(char ch);
     void initQssStyleSheet();
     long xcount;


### PR DESCRIPTION
Close #21

Fixed the bug where spaces and odd-length characters caused errors in Hex send mode.

Changes:
1. Removed spaces from input string using RegExp.
2. Added padding '0' for odd-length input.
3. Verified with loopback test.